### PR TITLE
Now works on android build tools for gradle v0.11+

### DIFF
--- a/gradle-android-cq-plugin/src/main/groovy/com/github/nrudenko/gradle/cq/AndroidCheckstyleTask.groovy
+++ b/gradle-android-cq-plugin/src/main/groovy/com/github/nrudenko/gradle/cq/AndroidCheckstyleTask.groovy
@@ -47,11 +47,7 @@ class AndroidCheckstyleTask extends BaseStatisticTask {
             // see also, maxWarnings and failureProperty arguments
             ant.checkstyle(config: configFile, failOnViolation: !ignoreFailures) {
                 fileset(dir: gradleProject.projectDir.getPath()) {
-                    gradleProject.android.sourceSets.each { sourceSet ->
-                        sourceSet.java.each { file ->
-                            include(name: gradleProject.relativePath(file))
-                        }
-                    }
+                    applyToFileSet({file -> include(name: gradleProject.relativePath(file))})
                 }
                 if (showViolations) {
                     formatter(type: 'plain', useFile: false)

--- a/gradle-android-cq-plugin/src/main/groovy/com/github/nrudenko/gradle/cq/AndroidCpdTask.groovy
+++ b/gradle-android-cq-plugin/src/main/groovy/com/github/nrudenko/gradle/cq/AndroidCpdTask.groovy
@@ -31,11 +31,7 @@ class AndroidCpdTask extends BaseStatisticTask {
                     outputFile: outputPath
             ) {
                 fileset(dir: gradleProject.projectDir.getPath()) {
-                    gradleProject.android.sourceSets.each { sourceSet ->
-                        sourceSet.java.each { file ->
-                            include(name: gradleProject.relativePath(file))
-                        }
-                    }
+                    applyToFileSet({file -> include(name: gradleProject.relativePath(file))})
                 }
             }
 

--- a/gradle-android-cq-plugin/src/main/groovy/com/github/nrudenko/gradle/cq/AndroidPmdTask.groovy
+++ b/gradle-android-cq-plugin/src/main/groovy/com/github/nrudenko/gradle/cq/AndroidPmdTask.groovy
@@ -50,11 +50,7 @@ class AndroidPmdTask extends BaseStatisticTask {
                     rulesetfiles: rulesetFile.toURI().toString()) {
                 formatter(type: 'xml', toFile: outputFile, toConsole: showViolations)
                 fileset(dir: gradleProject.projectDir.getPath()) {
-                    gradleProject.android.sourceSets.each { sourceSet ->
-                        sourceSet.java.each { file ->
-                            include(name: gradleProject.relativePath(file))
-                        }
-                    }
+                    applyToFileSet({file -> include(name: gradleProject.relativePath(file))})
                 }
             }
             makeHtml(ant)

--- a/gradle-android-cq-plugin/src/main/groovy/com/github/nrudenko/gradle/cq/BaseStatisticTask.groovy
+++ b/gradle-android-cq-plugin/src/main/groovy/com/github/nrudenko/gradle/cq/BaseStatisticTask.groovy
@@ -50,6 +50,20 @@ abstract class BaseStatisticTask extends DefaultTask {
         file
     }
 
+    def applyToFileSet(Closure func){
+        gradleProject.android.sourceSets.each { sourceSet ->
+            sourceSet.javaDirectories.each { dir ->
+                if (dir.exists()) {
+                    dir.eachDirRecurse() { subDir ->
+                        subDir.eachFileMatch(~/.*.java/) { file ->
+                            func(file)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
     void makeHtml(def ant) {
         if (outputFile.exists() && xslFile != null && xslFile.exists()) {
             ant.xslt(in: outputFile,


### PR DESCRIPTION
Android build tools update to v0.11 changed the DefaultAndroidSourceSet.getJava() return type, so android-cp wasn't able to generate correct file set for checkstyle, pmd and cpd.  This fix utilises different approach and generates the fileset by itself and works both on elder and newer versions.
