### PR TITLE
Updated dependencies for findbugs checkstyle and pmd

### DIFF
--- a/gradle-android-cq-plugin/src/main/groovy/com/github/nrudenko/gradle/cq/AndroidCQPlugin.groovy
+++ b/gradle-android-cq-plugin/src/main/groovy/com/github/nrudenko/gradle/cq/AndroidCQPlugin.groovy
@@ -14,10 +14,10 @@ public class AndroidCQPlugin implements Plugin<Project> {
         project.configurations.create('findbugsPlugins')
         project.configurations.create('codequality')
 
-        project.dependencies.add('compile', 'com.google.code.findbugs:annotations:2.0.0')
-        project.dependencies.add('findbugs', 'com.google.code.findbugs:findbugs-ant:2.0.2')
-        project.dependencies.add('codequality', 'com.puppycrawl.tools:checkstyle:5.6')
-        project.dependencies.add('codequality', 'pmd:pmd:4.2.6')
+        project.dependencies.add('compile', 'com.google.code.findbugs:annotations:3.0.1')
+        project.dependencies.add('findbugs', 'com.google.code.findbugs:findbugs-ant:3.0.0')
+        project.dependencies.add('codequality', 'com.puppycrawl.tools:checkstyle:6.14.1')
+        project.dependencies.add('codequality', 'pmd:pmd:4.3')
 
         project.task('findbugs', type: AndroidFindBugsTask)
         project.task('checkstyle', type: AndroidCheckstyleTask)


### PR DESCRIPTION
The dependencies in the plugin task are currently pretty outdated. This PR fixes them.